### PR TITLE
docs: add javascript ternary operator

### DIFF
--- a/src/data/roadmaps/javascript/content/107-javascript-control-flow/101-conditional-statements/102-ternary-operator.md
+++ b/src/data/roadmaps/javascript/content/107-javascript-control-flow/101-conditional-statements/102-ternary-operator.md
@@ -1,0 +1,13 @@
+# ternary operator
+
+The conditional (ternary) operator is the only JavaScript operator that takes three operands: a `condition` followed by a `question mark (?)`, then an `expression to execute` if the condition is `truthy` followed by a `colon (:)`, and finally the `expression to execute` if the condition is `falsy`.
+
+## Example
+
+```js
+condition ? exprIfTrue : exprIfFalse;
+```
+
+Visit the following resources to learn more:
+
+- [ternary operator - MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_operator)


### PR DESCRIPTION
As a beginner myself, I’ve been using roadmap.sh to guide me through various technologies. However, I noticed that an important concept like the ternary operator in JavaScript wasn’t mentioned. I believe it would be helpful to include it as its own node, as many beginners (myself included) often find the syntax confusing at first. Spending some time to understand it properly would be really beneficial.